### PR TITLE
Add support for `this` in `wrap`

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ export function wrap(middleware, callback) {
     }
 
     try {
-      result = middleware(...parameters)
+      result = middleware.apply(this, parameters)
     } catch (error) {
       /** @type {Error} */
       const exception = error


### PR DESCRIPTION
Use `middleware.apply(this, parameters)` to pass the `this` value from the wrapper to the wrapped function.

The wrapped package [used to do this](https://github.com/matthewmueller/wrapped/blob/3529c98e892478c779cd3934c014c79b25d88789/index.js#L54) --- unified-lint-rule [switched from that package to trough](https://github.com/remarkjs/remark-lint/commit/b81b38a4f91deb1a6b5d7257c15dbebb9001fe14).

I'm interested in [giving remark lint rules access to `settings`](https://github.com/remarkjs/remark-lint/pull/279), and one way is [via the `this` value](https://github.com/remarkjs/remark-lint/issues/263#issuecomment-903311532).